### PR TITLE
Fix NameError by importing Union from typing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,4 @@
 import urllib.parse
-from datetime import datetime
 
 import numpy as np
 from flask import Flask, jsonify, request

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy==1.25.1
 sentence-transformers==2.2.2
 Flask-Cors==4.0.0
 scikit-learn==1.3.0
+pytest==7.4.2

--- a/tables/table.py
+++ b/tables/table.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Union
 
 import numpy as np
 


### PR DESCRIPTION
This pull request addresses the `NameError` that arises from attempting to use the `Union` type in the `table.py` file. This error prevents the app from running.

@MananSuri27, please update your Docker images accordingly.

Changes Made:

- Imported the `Union` type from the `typing` module.
- Removed `datetime` unused import from `app.py`.
- Added `pytest` dependency to `requirements.txt`.
